### PR TITLE
travis: attempt to set up Travis-CI on new tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.5"
+before_install:
+  - "sudo apt-get update && sudo apt-get install --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra texlive-latex-recommended dvipng"
+script:
+  - cd build/ && python -m unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 python:
   - "3.5"
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
 before_install:
   - "sudo apt-get update && sudo apt-get install --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra texlive-latex-recommended dvipng"
 script:

--- a/education.json
+++ b/education.json
@@ -1,5 +1,5 @@
 [
-  {
+  
     "school_name":"Rochester Institute of Technology",
     "school_city":"Rochester",
     "school_state":"NY",

--- a/education.json
+++ b/education.json
@@ -1,5 +1,5 @@
 [
-  
+  {
     "school_name":"Rochester Institute of Technology",
     "school_city":"Rochester",
     "school_state":"NY",


### PR DESCRIPTION
### Background
it's good to have the peace of mind that 
- nothing has broken my the `.json` and output `Resume_Sawyer.pdf` file creation now that I'm consuming them in my main site 
- i have continuing support for past `python` versions, given my intention to keep this as a reusable open source project.

after writing the tests to ensure:
- working helpers 
- end-to-end functionality
- healthy and valid `.json` files

... I want to use travis-ci to trigger them on every PR to ensure that nothing breaking gets to whatever branch i'm working off of (`master`, `develop`, etc.)

### Description of Changes
- register `atla5/resume` on my Travis-CI account
- write up a `.travis.yml` file in the main directory 