### PR TITLE
test: add tests and travis-ci to ensure non-breaking changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "3.5"
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+before_install:
+  - "sudo apt-get update && sudo apt-get install --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra texlive-latex-recommended dvipng"
+script:
+  - cd build/ && python -m unittest

--- a/build/build_resume.py
+++ b/build/build_resume.py
@@ -38,7 +38,7 @@ def update_values(dict_values):
     generate_languages(dict_values, languages)
 
 
-if __name__ == "__main__":
+def build_resume():
 
     # create and update value dictionary from json files
     dict_values = {
@@ -77,3 +77,6 @@ if __name__ == "__main__":
     os.system("rm *.log")
     os.system("rm *.aux")
     os.system("rm -rf __pycache__")
+
+if __name__ == "__main__":
+    build_resume()

--- a/build/test_build.py
+++ b/build/test_build.py
@@ -2,26 +2,6 @@ import unittest
 import os, json, csv
 from update_values_helpers import *
 
-
-SAMPLE_SCHOOL = {
-    "company_name": "COMPANY_NAME",
-    "company_url": "https://www.company-url.com",
-    "advisor_name": "FNAME LNAME",
-    "advisor_contact": "fname.lname@company.org",
-    "advisor_position": "position",
-    "location_city": "CITY",
-    "location_state": "MA",
-    "time_start": "2017-01",
-    "time_end": "2017-12",
-    "position": "POSITION AT COMPANY",
-    "responsibilities": [
-      "RESPONSIBILITY ONE...",
-      "RESPONSIBILITY TWO...",
-      "RESPONSIBILITY THREE..."
-    ],
-    "summary_short": "A short description",
-    "summary_long": "A not so short description of what i did when i worked here."
-  }
 data_dir = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
 
 

--- a/build/test_build.py
+++ b/build/test_build.py
@@ -1,4 +1,5 @@
 import unittest
+import os, json
 from update_values_helpers import *
 
 
@@ -21,6 +22,7 @@ SAMPLE_SCHOOL = {
     "summary_short": "A short description",
     "summary_long": "A not so short description of what i did when i worked here."
   }
+data_dir = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
 
 
 class TestBuild(unittest.TestCase):
@@ -36,3 +38,13 @@ class TestBuild(unittest.TestCase):
         self.assertEqual("one fish", humanize_list(["one fish"]))
         self.assertEqual("", humanize_list([""]))
         self.assertEqual("1, 2, 3, 4", humanize_list([1, 2, 3, "4"]))
+
+    def test_valid_json_data(self):
+        for filename in os.listdir(data_dir):
+            if filename.endswith('.json'):
+                try:
+                    with open(os.path.join(data_dir,filename), 'r') as file:
+                        json.loads(file.read())
+                except ValueError:
+                    self.fail("linting error found in {}".format(filename))
+

--- a/build/test_build.py
+++ b/build/test_build.py
@@ -1,8 +1,15 @@
 import unittest
 import os, json, csv
-from update_values_helpers import *
 
+from update_values_helpers import humanize_date, humanize_list
+from build_resume import build_resume
+
+build_dir = os.path.abspath(os.getcwd())
 data_dir = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
+
+
+def get_time_created_or_zero(filename):
+    return os.path.getctime(filename) if os.path.exists(filename) else 0
 
 
 class TestBuild(unittest.TestCase):
@@ -39,3 +46,24 @@ class TestBuild(unittest.TestCase):
 
                 except Exception:
                     self.fail("error reading csv file: {}".format(filename))
+
+    def test_build_resume(self):
+
+        output_filename_prefix = "Resume_Sawyer"
+
+        # get the 'created' timestamp any existing output files were created, defaulting to zero
+        output_tex_timestamp_before = get_time_created_or_zero("{}.tex".format(output_filename_prefix))
+        output_pdf_timestamp_before = get_time_created_or_zero("{}.pdf".format(output_filename_prefix))
+
+        try:
+            build_resume()
+        except Exception:
+            self.fail("Exception occurred while attempting to build output")
+
+        # get the 'created' timestamp of our fresh output files
+        output_tex_timestamp_after = get_time_created_or_zero("{}.tex".format(output_filename_prefix))
+        output_pdf_timestamp_after = get_time_created_or_zero("{}.pdf".format(output_filename_prefix))
+
+        # ensure that build_resume() effectively created both files (_note: if both default to zero, it still fails_)
+        self.assertGreater(output_tex_timestamp_after, output_tex_timestamp_before)
+        self.assertGreater(output_pdf_timestamp_after, output_pdf_timestamp_before)

--- a/build/test_build.py
+++ b/build/test_build.py
@@ -1,5 +1,5 @@
 import unittest
-import os, json
+import os, json, csv
 from update_values_helpers import *
 
 
@@ -48,3 +48,14 @@ class TestBuild(unittest.TestCase):
                 except ValueError:
                     self.fail("linting error found in {}".format(filename))
 
+    def test_valid_csv_data(self):
+        for filename in os.listdir(data_dir):
+            if filename.endswith('.csv'):
+                try:
+                    with open(os.path.join(data_dir, filename), 'r') as csvfile:
+                        for row in csv.reader(csvfile, delimiter=','):
+                            if not bool(row) or not isinstance(row, list) or not all(isinstance(elem, str) for elem in row):
+                                self.fail("error rendering csv file '{}' into list of strings.".format(filename))
+
+                except Exception:
+                    self.fail("error reading csv file: {}".format(filename))

--- a/build/test_build.py
+++ b/build/test_build.py
@@ -1,13 +1,38 @@
 import unittest
-from update_values_helper import *
+from update_values_helpers import *
+
+
+SAMPLE_SCHOOL = {
+    "company_name": "COMPANY_NAME",
+    "company_url": "https://www.company-url.com",
+    "advisor_name": "FNAME LNAME",
+    "advisor_contact": "fname.lname@company.org",
+    "advisor_position": "position",
+    "location_city": "CITY",
+    "location_state": "MA",
+    "time_start": "2017-01",
+    "time_end": "2017-12",
+    "position": "POSITION AT COMPANY",
+    "responsibilities": [
+      "RESPONSIBILITY ONE...",
+      "RESPONSIBILITY TWO...",
+      "RESPONSIBILITY THREE..."
+    ],
+    "summary_short": "A short description",
+    "summary_long": "A not so short description of what i did when i worked here."
+  }
 
 
 class TestBuild(unittest.TestCase):
-
-    def __init__(self):
-        self.sample_school = SAMPLE_SCHOOL
 
     def test_humanize_date(self):
         self.assertEqual("Jan 2017", humanize_date("2017-01"))
         self.assertEqual("2017-13",  humanize_date("2017-13"))
         self.assertEqual("2017-00",  humanize_date("2017-00"))
+
+    def test_humanize_list(self):
+        self.assertEqual("one fish, two fish, red fish, blue fish", humanize_list(["one fish", "two fish", "red fish", "blue fish"]))
+        self.assertEqual("one fish, two fish", humanize_list(["one fish", "two fish"]))
+        self.assertEqual("one fish", humanize_list(["one fish"]))
+        self.assertEqual("", humanize_list([""]))
+        self.assertEqual("1, 2, 3, 4", humanize_list([1, 2, 3, "4"]))

--- a/build/test_build.py
+++ b/build/test_build.py
@@ -1,0 +1,13 @@
+import unittest
+from update_values_helper import *
+
+
+class TestBuild(unittest.TestCase):
+
+    def __init__(self):
+        self.sample_school = SAMPLE_SCHOOL
+
+    def test_humanize_date(self):
+        self.assertEqual("Jan 2017", humanize_date("2017-01"))
+        self.assertEqual("2017-13",  humanize_date("2017-13"))
+        self.assertEqual("2017-00",  humanize_date("2017-00"))

--- a/build/update_values_helpers.py
+++ b/build/update_values_helpers.py
@@ -42,7 +42,7 @@ def humanize_date(yyyy_mm):
 
 
 def humanize_list(ls):
-    return ", ".join(s for s in ls).rstrip(", ")
+    return ", ".join(str(s) for s in ls).rstrip(", ")
 
 
 def generate_school_info(dict_values, school, id=None):
@@ -115,3 +115,14 @@ def generate_languages(dict_values, languages):
     generate_language_entry(dict_values, lvl_1, ls_intermediate, 1)
     generate_language_entry(dict_values, lvl_2, ls_functional, 2)
     generate_language_entry(dict_values, lvl_3, ls_limited, 3)
+
+
+import unittest
+
+
+class TestBuild(unittest.TestCase):
+
+    def test_humanize_date(self):
+        self.assertEqual("Jan 2017", humanize_date("2017-01"))
+        self.assertEqual("2017-13", humanize_date("2017-13"))
+        self.assertEqual("2017-00", humanize_date("2017-00"))

--- a/build/update_values_helpers.py
+++ b/build/update_values_helpers.py
@@ -3,6 +3,8 @@
 # license: MIT
 # purpose: customize dict_values according to passed values
 
+import sys
+
 months = ["Jan", "Feb", "March", "April", "May", "June", "July", "Aug", "Sept", "Oct", "Nov", "Dec"]
 
 
@@ -20,11 +22,23 @@ def generate_about(dict_values, about):
 
 
 def humanize_date(yyyy_mm):
-    tokens = yyyy_mm.split('-')
-    year = tokens[0]
-    month = int(tokens[1])
+    output = yyyy_mm
 
-    return "{} {}".format(months[month-1], year)
+    try:
+        tokens = yyyy_mm.split('-')
+        year = tokens[0]
+        month = int(tokens[1])
+
+        if 0 < month <= 12:
+            output = "{} {}".format(months[month-1], year)
+        else:
+            sys.stdout.write("Invalid month: {}\n".format(yyyy_mm))
+
+    except IndexError:
+        sys.stdout.write("Improperly formatted date: {}\n".format(yyyy_mm))
+
+    finally:
+        return output
 
 
 def humanize_list(ls):

--- a/build/update_values_helpers.py
+++ b/build/update_values_helpers.py
@@ -115,14 +115,3 @@ def generate_languages(dict_values, languages):
     generate_language_entry(dict_values, lvl_1, ls_intermediate, 1)
     generate_language_entry(dict_values, lvl_2, ls_functional, 2)
     generate_language_entry(dict_values, lvl_3, ls_limited, 3)
-
-
-import unittest
-
-
-class TestBuild(unittest.TestCase):
-
-    def test_humanize_date(self):
-        self.assertEqual("Jan 2017", humanize_date("2017-01"))
-        self.assertEqual("2017-13", humanize_date("2017-13"))
-        self.assertEqual("2017-00", humanize_date("2017-00"))


### PR DESCRIPTION
Fixes #11  

### Background
- since i'm consuming both the data (`*.json`) and the output file (`Resume_Sawyer.pdf`), i want to make sure it's never broken on prod
- the best way to do that is to automate a robust testing suite 

### Description of Changes:
- write new testing suite in `build/test_build.py` with `unittest` module
- fix some of the 
- trigger these tests (on multiple `python` versions) via Jenkins on all PRs 

### Out of Scope
- I'm not writing any `pact`s or testing any contracts here, so all of this code is correct or not in accordance with _itself_ and not with the other repo
- if i, say, move all the `.json` files into a new `data/` directory, my usage of these files will break without this saying anything